### PR TITLE
Setting defaults for CF9. Since they will always get overwritten 

### DIFF
--- a/models/PasswordManager.cfc
+++ b/models/PasswordManager.cfc
@@ -25,8 +25,8 @@ component accessors='true' {
 		var propertyFile = wirebox.getInstance( 'PropertyFile@PropertyFile' )
 			.load( seedpropertiesPath );
 		
-		setSeed( propertyFile.get( 'seed', '' ) );
-    	setAlgorithm( propertyFile.get( 'algorithm', '' ) );
+		setSeed( propertyFile.get( 'seed', '0yJ!@1$r8p0L@r1$6yJ!@1rj' ) );
+    	setAlgorithm( propertyFile.get( 'algorithm', 'DESede' ) );
     	
     	return this;
 	}


### PR DESCRIPTION
This is needed for getting the CF9 Password from cfconfig since there is no seed.properties file but a password.properties file (That doesn't contain the hardcoded seed)